### PR TITLE
Update EventListener.php

### DIFF
--- a/src/BreakReplace/EventListener.php
+++ b/src/BreakReplace/EventListener.php
@@ -15,7 +15,7 @@ class EventListener implements Listener {
     /**
      * @param BlockBreakEvent $event
      *
-     * @priority MONITOR
+     * @priority HIGHEST
      * @ignoreCancelled true
      */
     public function onBreak(BlockBreakEvent $event) {
@@ -26,13 +26,11 @@ class EventListener implements Listener {
         $vector3 = new Vector3($block->x, $block->y, $block->z);
         if($this->plugin->getBRStatus($player)) {
             if($item->canBePlaced()) {
-                $player->getLevel()->setBlock($vector3, Block::get($item->getId(), $item->getDamage()), true, true);
+                $player->getLevel()->setBlock($vector3, $item->getBlock(), true, true);
                 if(!$player->isCreative()) {
-                    $player->getInventory()->removeItem(Item::get($item->getId(), $item->getDamage(), 1));
+                    $player->getInventory()->removeItem(Item::get($item->getId(), $item->getDamage()));
                 }
-                foreach($drops as $drop) {
-                    $player->getInventory()->addItem($drop);
-                }
+                $player->getInventory()->addItem(...$drops);
                 $event->setCancelled();
             }
         }

--- a/src/BreakReplace/EventListener.php
+++ b/src/BreakReplace/EventListener.php
@@ -1,11 +1,9 @@
 <?php
 namespace BreakReplace;
 
-use pocketmine\block\Block;
 use pocketmine\event\block\BlockBreakEvent;
 use pocketmine\event\Listener;
 use pocketmine\item\Item;
-use pocketmine\math\Vector3;
 
 class EventListener implements Listener {
     public function __construct($plugin) {
@@ -23,12 +21,11 @@ class EventListener implements Listener {
         $block = $event->getBlock();
         $item = $event->getItem();
         $drops = $event->getDrops();
-        $vector3 = new Vector3($block->x, $block->y, $block->z);
         if($this->plugin->getBRStatus($player)) {
             if($item->canBePlaced()) {
-                $player->getLevel()->setBlock($vector3, $item->getBlock(), true, true);
+                $player->getLevel()->setBlock($block, $item->getBlock(), true, true);
                 if(!$player->isCreative()) {
-                    $player->getInventory()->removeItem(Item::get($item->getId(), $item->getDamage()));
+                    $player->getInventory()->removeItem($item);
                 }
                 $player->getInventory()->addItem(...$drops);
                 $event->setCancelled();


### PR DESCRIPTION
Your plugin has been rejected due to poor namespace. Please conform to [PQRS](https://poggit.pmmp.io/pqrs) -- your plugin is far too simple to have its own top-level namespace.

Other than that, Avoid cancelling event in a MONITOR-level event handler. Should be HIGHEST instead; otherwise MONITOR level plugins MAY NOT be able to detect this cancellation.

Also, use $item->getBlock() instead of Block::get(), because this won't work with items that can place blocks but not directly items, such as WheatSeeds.

This pull request also improved performance by making only a single call to PlayerInventory::addItem().

P.S. Not a problem, but making an EventListener class or making your commands have their own classes won't make your plugin any more professional if there is no such need at all -- In simple plugins, making everything one class will make it easier to manage, as it's very unlikely that you will add much more to the plugin in the future.